### PR TITLE
feat: add dynamic labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,17 @@ Basic usage is simple:
 package myapp
 
 import (
+  "fmt"
+
   "github.com/edge/logger"
 )
 
 func main() {
-  l := logger.New().SetLabel("app", "com.example.myapp")
+  n := 0
+  l := logger.New().SetLabel("app", "com.example.myapp").SetDynamicLabel("nr", func () string {
+    n++
+    return fmt.Sprintf("%d", n)
+  })
   go func() {
     l.Context("main.go_func").Info("Goroutine works")
   }()

--- a/logger_test.go
+++ b/logger_test.go
@@ -46,6 +46,31 @@ func Test_Logger_Context(t *testing.T) {
 	}
 }
 
+func Test_Logger_DynamicLabel(t *testing.T) {
+	a := assert.New(t)
+
+	n := 0
+	l := newWithTestHandler(func(e *Entry) {
+		for k, v := range e.Labels {
+			a.Equal("dyn", k)
+			a.Equal(fmt.Sprintf("%d", n), v)
+		}
+	})
+	l.SetDynamicLabel("dyn", func() string {
+		n++
+		return fmt.Sprintf("%d", n)
+	})
+
+	x := 0
+	for {
+		x++
+		l.Context("test").Infof("dynamic log - should show dyn=%d", x)
+		if x == 10 {
+			break
+		}
+	}
+}
+
 func Test_Logger_Label(t *testing.T) {
 	a := assert.New(t)
 


### PR DESCRIPTION
While migrating one of our apps to this logger, I discovered a worthy use case for dynamic labels - but in logrus there isn't a strict distinction between dynamic and static labels. I've restored that functionality with more-explicit naming.

Not waiting for a review on this one - PR is a formality to document the addition 👍 