### PR TITLE
Logging colour and sorting methods

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -5,7 +5,7 @@ import "fmt"
 // Entry represents a single log entry.
 type Entry struct {
 	Context  string
-	Labels   map[string]string
+	Labels   *Labels
 	Severity Severity
 	Message  []interface{}
 
@@ -53,8 +53,17 @@ func (e *Entry) Infof(format string, args ...interface{}) {
 }
 
 // Label sets a label on the entry. The same entry is returned.
-func (e *Entry) Label(k, v string) *Entry {
-	e.Labels[k] = v
+func (e *Entry) Label(k string, v interface{}) *Entry {
+	for _, lbl := range *e.Labels {
+		if lbl.k == k {
+			lbl.v = v
+			goto SORT
+		}
+	}
+	// Insert new label
+	*e.Labels = append(*e.Labels, &Label{k, v})
+SORT:
+	e.Labels.Sort()
 	return e
 }
 

--- a/labels.go
+++ b/labels.go
@@ -1,0 +1,39 @@
+package logger
+
+import (
+	"fmt"
+	"sort"
+)
+
+type Labels []*Label
+
+func (l Labels) Len() int           { return len(l) }
+func (l Labels) Swap(i, j int)      { l[i], l[j] = l[j], l[i] }
+func (l Labels) Less(i, j int) bool { return l[i].k < l[j].k }
+
+// Sort triggers Labels sorting method.
+func (l *Labels) Sort() {
+	sort.Sort(l)
+}
+
+type Label struct {
+	k string
+	v interface{}
+}
+
+// Out outputs the label as a key=val string.
+func (l *Label) Out() string {
+	return fmt.Sprintf(`%s=%s`, l.k, l.Val())
+}
+
+// Val returns the value of the label.
+func (l *Label) Val() string {
+	switch v := l.v.(type) {
+	case string:
+		return v
+	case func() string:
+		return v()
+	default:
+		return ""
+	}
+}

--- a/labels.go
+++ b/labels.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 )
 
+// Labels stores all label instances.
 type Labels []*Label
 
 func (l Labels) Len() int           { return len(l) }
@@ -16,9 +17,10 @@ func (l *Labels) Sort() {
 	sort.Sort(l)
 }
 
+// Label stores the label key and value
 type Label struct {
 	k string
-	v interface{}
+	v interface{} // string, func() string
 }
 
 // Out outputs the label as a key=val string.

--- a/severity.go
+++ b/severity.go
@@ -2,28 +2,34 @@ package logger
 
 const (
 	// Fatal error/panic, not recoverable
-	Fatal     Severity = 0
-	fatalText string   = "FATAL"
+	Fatal      Severity = 0
+	fatalText  string   = "FATAL"
+	fatalColor uint16   = 31 // red
 
 	// Error encountered, possibly recoverable
-	Error     Severity = 1
-	errorText string   = "ERROR"
+	Error      Severity = 1
+	errorText  string   = "ERROR"
+	errorColor uint16   = 31 // red
 
 	// Warn of potential operating concerns or failure trajectory
-	Warn     Severity = 2
-	warnText string   = "WARN"
+	Warn      Severity = 2
+	warnText  string   = "WARN"
+	warnColor uint16   = 33 // yellow
 
 	// Info updates
-	Info     Severity = 3
-	infoText string   = "INFO"
+	Info      Severity = 3
+	infoText  string   = "INFO"
+	infoColor uint16   = 36 // blue
 
 	// Debug data. Solely used in development
-	Debug     Severity = 4
-	debugText string   = "DEBUG"
+	Debug      Severity = 4
+	debugText  string   = "DEBUG"
+	debugColor uint16   = 37 // grey
 
 	// Trace data. Solely used in development
-	Trace     Severity = 5
-	traceText string   = "TRACE"
+	Trace      Severity = 5
+	traceText  string   = "TRACE"
+	traceColor uint16   = 37 // grey
 )
 
 // Severity of a log entry is represented by a number where 0 is most severe (Fatal) and N is least.
@@ -38,6 +44,37 @@ func GetSeverities() map[Severity]string {
 		Info:  infoText,
 		Debug: debugText,
 		Trace: traceText,
+	}
+}
+
+// GetSeverityColors returns a dictionary of severity colors indexed by their internal values.
+func GetSeverityColors() map[Severity]uint16 {
+	return map[Severity]uint16{
+		Fatal: fatalColor,
+		Error: errorColor,
+		Warn:  warnColor,
+		Info:  infoColor,
+		Debug: debugColor,
+		Trace: traceColor,
+	}
+}
+
+func severityIntToColor(s Severity) uint16 {
+	switch s {
+	case Debug:
+		return debugColor
+	case Error:
+		return errorColor
+	case Fatal:
+		return fatalColor
+	case Info:
+		return infoColor
+	case Trace:
+		return traceColor
+	case Warn:
+		return warnColor
+	default:
+		return debugColor
 	}
 }
 

--- a/severity_test.go
+++ b/severity_test.go
@@ -25,6 +25,22 @@ func Test_severityIntToText_NotOk(t *testing.T) {
 	}
 }
 
+func Test_severityIntToColor(t *testing.T) {
+	a := assert.New(t)
+	severities := GetSeverityColors()
+	for i, ta := range severities {
+		tc := severityIntToColor(i)
+		a.Equal(ta, tc)
+	}
+}
+
+func Test_severityIntToColor_NotOK(t *testing.T) {
+	a := assert.New(t)
+	textColor := severityIntToColor(6)
+	defaultColor := uint16(37) // grey
+	a.Equal(defaultColor, textColor, "Should default to 37 (grey)")
+}
+
 func Test_severityTextToInt(t *testing.T) {
 	a := assert.New(t)
 	severities := GetSeverities()

--- a/stdout.go
+++ b/stdout.go
@@ -2,59 +2,57 @@ package logger
 
 import (
 	"fmt"
-	"log"
+	"io"
 	"os"
 	"strings"
 	"time"
 )
 
+const newLine string = "\n"
+
 // StdoutHandler is a logger handler that outputs to stdout/stderr.
 type StdoutHandler struct {
 	timeLayout string
-
-	stderr *log.Logger
-	stdout *log.Logger
 }
 
 // NewStdoutHandler creates a new StdoutHandler.
 func NewStdoutHandler() *StdoutHandler {
 	return &StdoutHandler{
 		timeLayout: "2006-01-02 15:04:05.000 -0700 MST",
-
-		stderr: log.New(os.Stderr, "", 0),
-		stdout: log.New(os.Stdout, "", 0),
 	}
 }
 
 // Log an entry to stdout/stderr.
 func (s *StdoutHandler) Log(e *Entry) error {
-	line := s.formatEntry(e)
 	if e.Severity <= Error {
-		s.stderr.Println(line)
-	} else {
-		s.stdout.Println(line)
+		s.formatEntry(os.Stderr, e)
+		return nil
 	}
+	s.formatEntry(os.Stdout, e)
 	return nil
 }
 
-func (s *StdoutHandler) formatEntry(e *Entry) string {
+func (s *StdoutHandler) formatEntry(w io.Writer, e *Entry) {
 	labels := s.formatLabels(e)
 	logTime := time.Now().Format(s.timeLayout)
 	message := s.formatMessage(e)
 	textSeverity, _ := severityIntToText(e.Severity)
-	return fmt.Sprintf("%[2]s %- 7[1]s %[3]s [%[4]s]: %[5]s",
-		fmt.Sprintf("[%s]", textSeverity),
+	severityColor := severityIntToColor(e.Severity)
+	fmt.Fprintf(w, "\x1b[%[1]dm%- 5[2]s\x1b[0m %[3]s %[4]s [%[5]s]: %[6]s %s",
+		severityColor,
+		fmt.Sprintf("%s", textSeverity),
 		logTime,
 		e.Context,
 		labels,
 		message,
+		newLine,
 	)
 }
 
 func (*StdoutHandler) formatLabels(e *Entry) (labels string) {
 	ll := []string{}
-	for k, v := range e.Labels {
-		ll = append(ll, fmt.Sprintf("%s=%s", k, v))
+	for _, v := range *e.Labels {
+		ll = append(ll, v.Out())
 	}
 	return strings.Join(ll, " ")
 }


### PR DESCRIPTION
- Addresses the need for labels to be sorted alphanumerically
- Consolidates Labels and DynamicLabels by using type switch on an interface
- Adds colour to the label output
- Move the severity to be the first parameter
- Replaces `log` import with FPrintf io.Writer for os.Stderr and os.Stdout